### PR TITLE
Feature/tao 7232/readonly acl for prod

### DIFF
--- a/controller/Admin.php
+++ b/controller/Admin.php
@@ -208,7 +208,8 @@ class Admin extends \tao_actions_CommonModule {
      */
     private function isLocked()
     {
-        return !$this->getServiceLocator()->get(ApplicationService::SERVICE_ID)->isDebugMode();
+        return true;
+        // return !$this->getServiceLocator()->get(ApplicationService::SERVICE_ID)->isDebugMode();
     }
 
     /**

--- a/controller/Admin.php
+++ b/controller/Admin.php
@@ -208,8 +208,7 @@ class Admin extends \tao_actions_CommonModule {
      */
     private function isLocked()
     {
-        return true;
-        // return !$this->getServiceLocator()->get(ApplicationService::SERVICE_ID)->isDebugMode();
+        return !$this->getServiceLocator()->get(ApplicationService::SERVICE_ID)->isDebugMode();
     }
 
     /**

--- a/manifest.php
+++ b/manifest.php
@@ -30,7 +30,7 @@ return array(
     'label' => 'Functionality ACL',
 	'description' => 'Functionality Access Control Layer',
     'license' => 'GPL-2.0',
-    'version' => '5.1.1',
+    'version' => '5.2.0',
 	'author' => 'Open Assessment Technologies, CRP Henri Tudor',
 	'requires' => array(
         'tao' => '>=21.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -38,6 +38,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('4.0.0');
         }
 
-		$this->skip('4.0.0', '5.1.1');
+		$this->skip('4.0.0', '5.2.0');
     }
 }

--- a/views/js/controller/acl.js
+++ b/views/js/controller/acl.js
@@ -50,7 +50,7 @@ define(['jquery', 'context', 'util/encode', 'i18n'], function($, context, encode
 						groupCheckboxTitle = __('Grant access rights to the entire extension');
 						break;
 				}
-				var $group = $('<li class="group expendable closed'+extra+'"><div class="group-title"><span class="ui-icon ui-icon-triangle-1-e"/><span class="title">'+ ext['label'] +'</span>'
+				var $group = $('<li class="group expendable closed'+extra+'"><div class="group-title"><span class="icon icon-right"/> <span class="title">'+ ext['label'] +'</span>'
 					+ (data.locked ? '' : '<span class="selector all '+(ext['access'] == 'inherited' ? 'has-inherited' : 'checkable')+'" title="' + groupCheckboxTitle + '"></span>')
 					+ '</div><ul></ul></li>');
 				$group.acldata('uri', ext.uri);
@@ -79,13 +79,13 @@ define(['jquery', 'context', 'util/encode', 'i18n'], function($, context, encode
 					if ($(this).parent().hasClass('open')){
 						$(this).removeClass('open');
 						$(this).parent().removeClass('open').addClass('closed');
-						$(this).find('.ui-icon').removeClass('ui-icon-triangle-1-s').addClass('ui-icon-triangle-1-e');
+                        $(this).find('.icon').removeClass('icon-down').addClass('icon-right');
 						$(this).parent().find('.selected').removeClass('selected');
 					}
 					else {
 						$(this).addClass('open');
 						$(this).parent().removeClass('closed').addClass('open');
-						$(this).find('.ui-icon').removeClass('ui-icon-triangle-1-e').addClass('ui-icon-triangle-1-s');
+                        $(this).find('.icon').removeClass('icon-right').addClass('icon-down');
 					}
 				});
 				for (var m in ext.modules) {

--- a/views/js/controller/acl.js
+++ b/views/js/controller/acl.js
@@ -27,7 +27,11 @@ define(['jquery', 'context', 'util/encode', 'i18n'], function($, context, encode
 			}
 			for (var e in data['extensions']) {
 				var ext = data['extensions'][e];
-				
+
+				if (data.locked && ext['access'] !== 'inherited') {
+				    continue; // for the dev mode show only the checked
+                }
+
 				switch (ext['access']) {
 					case 'inherited':
 						groupCheckboxTitle = __('Inherited access to the extension');
@@ -47,7 +51,6 @@ define(['jquery', 'context', 'util/encode', 'i18n'], function($, context, encode
 						groupCheckboxTitle = __('Grant access rights to the entire extension');
 						break;
 				}
-
 				var $group = $('<li class="group expendable closed'+extra+'"><div class="group-title"><span class="ui-icon ui-icon-triangle-1-e"/><span class="title">'+ ext['label'] +'</span>'
 					+ (data.locked ? '' : '<span class="selector all '+(ext['access'] == 'inherited' ? 'has-inherited' : 'checkable')+'" title="' + groupCheckboxTitle + '"></span>')
 					+ '</div><ul></ul></li>');
@@ -88,6 +91,11 @@ define(['jquery', 'context', 'util/encode', 'i18n'], function($, context, encode
 				});
 				for (var m in ext.modules) {
 					var mod = ext.modules[m];
+
+                    if (data.locked && ext['access'] !== 'inherited') {
+                        continue; // for the dev mode show only the checked
+                    }
+
 					switch (mod['access']) {
 						case 'inherited':
 							modCheckboxTitle = __('Inherited access to the controller');
@@ -154,7 +162,11 @@ define(['jquery', 'context', 'util/encode', 'i18n'], function($, context, encode
 				$('#aclActions ul.group-list').empty();
 				for (e in data) {
 					var act = data[e];
-					
+
+                    if (act['locked'] && (act['access'] !== 'inherited' || !e)) {
+                        continue; // for the dev mode show only the checked
+                    }
+
 					var extra = '';
 					switch (act['access']) {
 						case 'inherited':

--- a/views/js/controller/acl.js
+++ b/views/js/controller/acl.js
@@ -47,9 +47,10 @@ define(['jquery', 'context', 'util/encode', 'i18n'], function($, context, encode
 						groupCheckboxTitle = __('Grant access rights to the entire extension');
 						break;
 				}
-				
+
 				var $group = $('<li class="group expendable closed'+extra+'"><div class="group-title"><span class="ui-icon ui-icon-triangle-1-e"/><span class="title">'+ ext['label'] +'</span>'
-						+ '<span class="selector all '+(ext['access'] == 'inherited' ? 'has-inherited' : 'checkable')+'" title="' + groupCheckboxTitle + '"></span></div><ul></ul></li>');
+					+ (data.locked ? '' : '<span class="selector all '+(ext['access'] == 'inherited' ? 'has-inherited' : 'checkable')+'" title="' + groupCheckboxTitle + '"></span>')
+					+ '</div><ul></ul></li>');
 				$group.acldata('uri', ext.uri);
 				
 				switch (ext['access']) {
@@ -107,7 +108,9 @@ define(['jquery', 'context', 'util/encode', 'i18n'], function($, context, encode
 							break;
 					}
 					
-					var $el = $('<li class="selectable'+extra+'"><span class="label">'+ mod['label'] +'</span><span class="selector '+(mod['access'] == 'inherited' ? 'has-inherited' : 'checkable') + '" title="'+ modCheckboxTitle +'"></span></li>');
+					var $el = $('<li class="selectable'+extra+'"><span class="label">'+ mod['label'] +'</span>'
+						+ (data.locked ? '' : '<span class="selector '+(mod['access'] == 'inherited' ? 'has-inherited' : 'checkable') + '" title="'+ modCheckboxTitle +'"></span>')
+						+'</li>');
 					$el.acldata('uri', mod.uri);
 					
 					switch (mod['access']) {
@@ -165,8 +168,10 @@ define(['jquery', 'context', 'util/encode', 'i18n'], function($, context, encode
 							// no access
 							actCheckBoxTitle = __('Grant access rights to the action');
 					}
-					
-					var $el = $('<li class="selectable'+extra+'"><span class="label">'+ e +'</span><span class="selector '+(act['access'] == 'inherited' ? 'has-inherited' : 'checkable')+'" title="'+ actCheckBoxTitle +'"></span></li>');
+
+					var $el = $('<li class="selectable'+extra+'"><span class="label">'+ e +'</span>'
+						+ (act['locked'] ? '' : '<span class="selector '+(act['access'] == 'inherited' ? 'has-inherited' : 'checkable')+'" title="'+ actCheckBoxTitle +'"></span>')
+						+ '</li>');
 					$el.acldata('uri', act.uri);
 
 					switch (act['access']) {

--- a/views/js/controller/acl.js
+++ b/views/js/controller/acl.js
@@ -178,7 +178,9 @@ define(['jquery', 'context', 'util/encode', 'i18n'], function($, context, encode
 							actCheckBoxTitle = __('Grant access rights to the action');
 					}
 
-					var $el = $('<li class="selectable'+extra+'"><span class="label">'+ e +'</span>'
+					var $el = $('<li class="selectable'+extra+'"'
+						+(act['locked'] ? ' style="cursor: default"' : '')
+						+'><span class="label">'+ e +'</span>'
 						+ (act['locked'] ? '' : '<span class="selector '+(act['access'] == 'inherited' ? 'has-inherited' : 'checkable')+'" title="'+ actCheckBoxTitle +'"></span>')
 						+ '</li>');
 					$el.acldata('uri', act.uri);

--- a/views/js/controller/acl.js
+++ b/views/js/controller/acl.js
@@ -28,10 +28,9 @@ define(['jquery', 'context', 'util/encode', 'i18n'], function($, context, encode
 			for (var e in data['extensions']) {
 				var ext = data['extensions'][e];
 
-				if (data.locked && ext['access'] !== 'inherited') {
+				if (data.locked && ext['access'] === 'none') {
 				    continue; // for the dev mode show only the checked
                 }
-
 				switch (ext['access']) {
 					case 'inherited':
 						groupCheckboxTitle = __('Inherited access to the extension');
@@ -91,11 +90,9 @@ define(['jquery', 'context', 'util/encode', 'i18n'], function($, context, encode
 				});
 				for (var m in ext.modules) {
 					var mod = ext.modules[m];
-
-                    if (data.locked && ext['access'] !== 'inherited') {
+                    if (data.locked && mod['access'] === 'none') {
                         continue; // for the dev mode show only the checked
                     }
-
 					switch (mod['access']) {
 						case 'inherited':
 							modCheckboxTitle = __('Inherited access to the controller');
@@ -163,7 +160,7 @@ define(['jquery', 'context', 'util/encode', 'i18n'], function($, context, encode
 				for (e in data) {
 					var act = data[e];
 
-                    if (act['locked'] && (act['access'] !== 'inherited' || !e)) {
+                    if (act['locked'] && (act['access'] === 'none')) {
                         continue; // for the dev mode show only the checked
                     }
 


### PR DESCRIPTION
To test it we need to switch environment to the production mode and after that compiled js will be used. (and I haven't created js bundles).
So I can create bundles or you can create bundles or you can use development mode but with code modification:
replace this https://github.com/oat-sa/extension-tao-funcacl/pull/63/files#diff-99dce5183f800359a30bb13c0ccaac69R211 with `return true;`

TAO-7266 included (https://github.com/oat-sa/extension-tao-funcacl/pull/63/commits/81c3925e1efc7a6724ddcea8104f3b0c23a4e9ba)