### PR TITLE
UDI-132: Manage schema - Remove access on property mgmt for normal UDIR authors

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -24,14 +24,14 @@
  * @author CRP Henri Tudor - TAO Team - {@link http://www.tao.lu}
  * @license GPLv2  http://www.opensource.org/licenses/gpl-2.0.php
  */
-$extpath = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+$extpath = __DIR__ . DIRECTORY_SEPARATOR;
 
 return [
     'name' => 'funcAcl',
     'label' => 'Functionality ACL',
     'description' => 'Functionality Access Control Layer',
     'license' => 'GPL-2.0',
-    'version' => '5.3.3',
+    'version' => '5.4.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=27.0.0',
@@ -42,10 +42,10 @@ return [
     ],
     'install' => [
         'rdf' => [
-            dirname(__FILE__) . '/models/ontology/taofuncacl.rdf'
+            __DIR__ . '/models/ontology/taofuncacl.rdf'
         ],
         'php' => [
-            dirname(__FILE__) . '/scripts/install/setFuncAclImpl.php'
+            __DIR__ . '/scripts/install/setFuncAclImpl.php'
         ],
     ],
     'update' => 'oat\\funcAcl\\scripts\\update\\Updater',
@@ -83,7 +83,7 @@ return [
         'TPL_PATH'  => $extpath . "views" . DIRECTORY_SEPARATOR . "templates" . DIRECTORY_SEPARATOR,
     ],
     'extra' => [
-        'structures' => dirname(__FILE__) . DIRECTORY_SEPARATOR . 'controller' . DIRECTORY_SEPARATOR . 'structures.xml',
+        'structures' => __DIR__ . DIRECTORY_SEPARATOR . 'controller' . DIRECTORY_SEPARATOR . 'structures.xml',
     ],
 
 ];

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -40,6 +40,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('4.0.0');
         }
 
-        $this->skip('4.0.0', '5.3.3');
+        $this->skip('4.0.0', '5.4.0');
     }
 }


### PR DESCRIPTION
- UDI-132 feat(ACL): allow revoking a permission during install-time by providing an `AccessRule::DENY` via `acl` table
- UDI-132 chore: remove an unused `FuncAcl::hasAccess()` argument
- UDI-132 chore: split terminating elseif workflows in various `FuncAcl` methods
- UDI-132 chore: remove `dirname()` function usages from `manifest.php`

To be used by: [`taoUdir` PR](https://github.com/oat-sa/extension-tao-udir/pull/34).