### PR TITLE
Change response in actions

### DIFF
--- a/controller/Admin.php
+++ b/controller/Admin.php
@@ -285,7 +285,10 @@ class Admin extends \tao_actions_CommonModule
         $uri = $this->getRequestParameter('uri');
         $extensionService = ExtensionAccessService::singleton();
         $extensionService->remove($role, $uri);
-        echo json_encode(['uri' => $uri]);
+
+        $this->returnJson([
+            'uri' => $uri,
+        ]);
     }
 
     /**
@@ -301,7 +304,10 @@ class Admin extends \tao_actions_CommonModule
         $uri = $this->getRequestParameter('uri');
         $extensionService = ExtensionAccessService::singleton();
         $extensionService->add($role, $uri);
-        echo json_encode(['uri' => $uri]);
+
+        $this->returnJson([
+            'uri' => $uri,
+        ]);
     }
 
     /**
@@ -317,7 +323,10 @@ class Admin extends \tao_actions_CommonModule
         $uri = $this->getRequestParameter('uri');
         $moduleService = ModuleAccessService::singleton();
         $moduleService->remove($role, $uri);
-        echo json_encode(['uri' => $uri]);
+
+        $this->returnJson([
+            'uri' => $uri,
+        ]);
     }
 
     /**
@@ -333,7 +342,10 @@ class Admin extends \tao_actions_CommonModule
         $uri = $this->getRequestParameter('uri');
         $moduleService = ModuleAccessService::singleton();
         $moduleService->add($role, $uri);
-        echo json_encode(['uri' => $uri]);
+
+        $this->returnJson([
+            'uri' => $uri,
+        ]);
     }
 
     /**
@@ -349,7 +361,10 @@ class Admin extends \tao_actions_CommonModule
         $uri = $this->getRequestParameter('uri');
         $actionService = ActionAccessService::singleton();
         $actionService->remove($role, $uri);
-        echo json_encode(['uri' => $uri]);
+
+        $this->returnJson([
+            'uri' => $uri,
+        ]);
     }
 
     /**
@@ -365,6 +380,9 @@ class Admin extends \tao_actions_CommonModule
         $uri = $this->getRequestParameter('uri');
         $actionService = ActionAccessService::singleton();
         $actionService->add($role, $uri);
-        echo json_encode(['uri' => $uri]);
+
+        $this->returnJson([
+            'uri' => $uri,
+        ]);
     }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return [
     'label' => 'Functionality ACL',
     'description' => 'Functionality Access Control Layer',
     'license' => 'GPL-2.0',
-    'version' => '5.6.0',
+    'version' => '5.6.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'tao' => '>=27.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -40,6 +40,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('4.0.0');
         }
 
-        $this->skip('4.0.0', '5.6.0');
+        $this->skip('4.0.0', '5.6.1');
     }
 }

--- a/test/unit/controller/AdminTest.php
+++ b/test/unit/controller/AdminTest.php
@@ -55,15 +55,14 @@ class AdminTest extends TestCase
         $_SERVER['HTTP_X_REQUESTED_WITH'] = 'xmlhttprequest';
 
         // At the moment controllers cannot be tested properly so we partially mock the class under test
-        $this->subject = $this->getMock(
-            Admin::class,
-            ['getRequest', 'defaultData', 'prodLocker', 'returnJson']
-        );
+        $this->subject = $this->getMockBuilder(Admin::class)
+            ->setMethods(['getRequest', 'defaultData', 'prodLocker', 'returnJson'])
+            ->getMock();
 
-        $this->applicationServiceMock = $this->getMock(ApplicationService::class);
-        $this->extensionAccessServiceMock = $this->getMock(ExtensionAccessService::class, [], [], '', false);
-        $this->moduleAccessServiceMock = $this->getMock(ModuleAccessService::class, [], [], '', false);
-        $this->actionAccessServiceMock = $this->getMock(ActionAccessService::class, [], [], '', false);
+        $this->applicationServiceMock = $this->createMock(ApplicationService::class);
+        $this->extensionAccessServiceMock = $this->createMock(ExtensionAccessService::class);
+        $this->moduleAccessServiceMock = $this->createMock(ModuleAccessService::class);
+        $this->actionAccessServiceMock = $this->createMock(ActionAccessService::class);
 
         $this->applicationServiceMock
             ->expects($this->once())
@@ -220,7 +219,7 @@ class AdminTest extends TestCase
      */
     private function getRequestMock(string $role, string $uri): Request
     {
-        $requestMock = $this->getMock(Request::class);
+        $requestMock = $this->createMock(Request::class);
 
         $requestMock
             ->method('getParameter')

--- a/test/unit/controller/AdminTest.php
+++ b/test/unit/controller/AdminTest.php
@@ -1,5 +1,23 @@
 <?php
 
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *q
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
 declare(strict_types=1);
 
 namespace oat\funcAcl\test\unit\controller;
@@ -11,6 +29,7 @@ use oat\funcAcl\models\ModuleAccessService;
 use oat\generis\test\MockObject;
 use oat\generis\test\TestCase;
 use oat\tao\model\service\ApplicationService;
+use ReflectionProperty;
 use Request;
 use tao_models_classes_Service;
 
@@ -56,7 +75,7 @@ class AdminTest extends TestCase
         ]));
 
         // AccessServices are not registered in the service manager, need to mock them in the global Service class
-        $instancesRef = new \ReflectionProperty(tao_models_classes_Service::class, 'instances');
+        $instancesRef = new ReflectionProperty(tao_models_classes_Service::class, 'instances');
         $instancesRef->setAccessible(true);
         $instancesRef->setValue(null, [
             ExtensionAccessService::class => $this->extensionAccessServiceMock,

--- a/test/unit/controller/AdminTest.php
+++ b/test/unit/controller/AdminTest.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\funcAcl\test\unit\controller;
+
+use oat\funcAcl\controller\Admin;
+use oat\funcAcl\models\ActionAccessService;
+use oat\funcAcl\models\ExtensionAccessService;
+use oat\funcAcl\models\ModuleAccessService;
+use oat\generis\test\MockObject;
+use oat\generis\test\TestCase;
+use oat\tao\model\service\ApplicationService;
+use Request;
+use tao_models_classes_Service;
+
+class AdminTest extends TestCase
+{
+    /** @var Admin|MockObject */
+    private $subject;
+
+    /** @var ApplicationService|MockObject */
+    private $applicationServiceMock;
+
+    /** @var ExtensionAccessService|MockObject */
+    private $extensionAccessServiceMock;
+
+    /** @var ModuleAccessService|MockObject */
+    private $moduleAccessServiceMock;
+
+    /** @var ActionAccessService|MockObject */
+    private $actionAccessServiceMock;
+
+    protected function setUp(): void
+    {
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = 'xmlhttprequest';
+
+        // At the moment controllers cannot be tested properly so we partially mock the class under test
+        $this->subject = $this->getMock(
+            Admin::class,
+            ['getRequest', 'defaultData', 'prodLocker', 'returnJson']
+        );
+
+        $this->applicationServiceMock = $this->getMock(ApplicationService::class);
+        $this->extensionAccessServiceMock = $this->getMock(ExtensionAccessService::class, [], [], '', false);
+        $this->moduleAccessServiceMock = $this->getMock(ModuleAccessService::class, [], [], '', false);
+        $this->actionAccessServiceMock = $this->getMock(ActionAccessService::class, [], [], '', false);
+
+        $this->applicationServiceMock
+            ->expects($this->once())
+            ->method('isDebugMode')
+            ->willReturn(true);
+
+        $this->subject->setServiceLocator($this->getServiceLocatorMock([
+            ApplicationService::SERVICE_ID => $this->applicationServiceMock,
+        ]));
+
+        // AccessServices are not registered in the service manager, need to mock them in the global Service class
+        $instancesRef = new \ReflectionProperty(tao_models_classes_Service::class, 'instances');
+        $instancesRef->setAccessible(true);
+        $instancesRef->setValue(null, [
+            ExtensionAccessService::class => $this->extensionAccessServiceMock,
+            ModuleAccessService::class => $this->moduleAccessServiceMock,
+            ActionAccessService::class => $this->actionAccessServiceMock,
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = null;
+    }
+
+    public function testRemoveExtensionAccess(): void
+    {
+        $this->extensionAccessServiceMock
+            ->expects($this->once())
+            ->method('remove')
+            ->with('foo', 'bar');
+
+        $this->subject
+            ->method('getRequest')
+            ->willReturn($this->getRequestMock('foo', 'bar'));
+
+        $this->subject
+            ->expects($this->once())
+            ->method('returnJson')
+            ->with([
+                'uri' => 'bar',
+            ]);
+
+        $this->subject->removeExtensionAccess();
+    }
+
+    public function testAddExtensionAccess(): void
+    {
+        $this->extensionAccessServiceMock
+            ->expects($this->once())
+            ->method('add')
+            ->with('foo', 'bar');
+
+        $this->subject
+            ->method('getRequest')
+            ->willReturn($this->getRequestMock('foo', 'bar'));
+
+        $this->subject
+            ->expects($this->once())
+            ->method('returnJson')
+            ->with([
+                'uri' => 'bar',
+            ]);
+
+        $this->subject->addExtensionAccess();
+    }
+
+    public function testRemoveModuleAccess(): void
+    {
+        $this->moduleAccessServiceMock
+            ->expects($this->once())
+            ->method('remove')
+            ->with('foo', 'bar');
+
+        $this->subject
+            ->method('getRequest')
+            ->willReturn($this->getRequestMock('foo', 'bar'));
+
+        $this->subject
+            ->expects($this->once())
+            ->method('returnJson')
+            ->with([
+                'uri' => 'bar',
+            ]);
+
+        $this->subject->removeModuleAccess();
+    }
+
+    public function testAddModuleAccess(): void
+    {
+        $this->moduleAccessServiceMock
+            ->expects($this->once())
+            ->method('add')
+            ->with('foo', 'bar');
+
+        $this->subject
+            ->method('getRequest')
+            ->willReturn($this->getRequestMock('foo', 'bar'));
+
+        $this->subject
+            ->expects($this->once())
+            ->method('returnJson')
+            ->with([
+                'uri' => 'bar',
+            ]);
+
+        $this->subject->addModuleAccess();
+    }
+
+    public function testRemoveActionAccess(): void
+    {
+        $this->actionAccessServiceMock
+            ->expects($this->once())
+            ->method('remove')
+            ->with('foo', 'bar');
+
+        $this->subject
+            ->method('getRequest')
+            ->willReturn($this->getRequestMock('foo', 'bar'));
+
+        $this->subject
+            ->expects($this->once())
+            ->method('returnJson')
+            ->with([
+                'uri' => 'bar',
+            ]);
+
+        $this->subject->removeActionAccess();
+    }
+
+    public function testAddActionAccess(): void
+    {
+        $this->actionAccessServiceMock
+            ->expects($this->once())
+            ->method('add')
+            ->with('foo', 'bar');
+
+        $this->subject
+            ->method('getRequest')
+            ->willReturn($this->getRequestMock('foo', 'bar'));
+
+        $this->subject
+            ->expects($this->once())
+            ->method('returnJson')
+            ->with([
+                'uri' => 'bar',
+            ]);
+
+        $this->subject->addActionAccess();
+    }
+
+    /**
+     * @return Request|MockObject
+     */
+    private function getRequestMock(string $role, string $uri): Request
+    {
+        $requestMock = $this->getMock(Request::class);
+
+        $requestMock
+            ->method('getParameter')
+            ->withConsecutive(['role'], ['uri'])
+            ->willReturnOnConsecutiveCalls($role, $uri);
+
+        return $requestMock;
+    }
+}


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/NEX-109

Previously the "Access Rights" functions were not working as the response were not adapted to the latest PSR7 changes and the API calls returned header errors. This PR provides fix for that.

To reproduce: log in to TAO and Users / Manage Access Rights. Then try to add and remove extension/module accesses.