### PR TITLE
fix: remove not working code and fix PHP8 compatibility

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -16,7 +16,7 @@ jobs:
         operating-system: [ ubuntu-latest ]
         php-version: [ '7.4', '8.0', '8.1' ]
         include:
-          - php-version: '7.4'
+          - php-version: '8.1'
             coverage: true
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=15.22",
-        "oat-sa/tao-core": ">=50.24.5",
+        "oat-sa/tao-core": ">=50.24.6",
         "oat-sa/extension-tao-backoffice": ">=6.0.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -61,12 +61,8 @@
     },
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-        "oat-sa/generis": ">=15.11.0",
-        "oat-sa/tao-core": ">=47.0.0",
+        "oat-sa/generis": ">=15.22",
+        "oat-sa/tao-core": ">=50.24.5",
         "oat-sa/extension-tao-backoffice": ">=6.0.0"
-    },
-    "require-dev": {
-        "oat-sa/generis": "dev-php8-migration as v16.0.0",
-        "oat-sa/tao-core": "dev-php8-migration as v51.0.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -64,5 +64,9 @@
         "oat-sa/generis": ">=15.11.0",
         "oat-sa/tao-core": ">=47.0.0",
         "oat-sa/extension-tao-backoffice": ">=6.0.0"
+    },
+    "require-dev": {
+        "oat-sa/generis": "dev-php8-migration as v16.0.0",
+        "oat-sa/tao-core": "dev-php8-migration as v51.0.0"
     }
 }

--- a/includes/raw_start.php
+++ b/includes/raw_start.php
@@ -24,5 +24,5 @@
 
 require_once dirname(__FILE__) . '/../../tao/includes/class.Bootstrap.php';
 
-$bootStrap = new BootStrap('funcAcl');
+$bootStrap = new Bootstrap('funcAcl');
 $bootStrap->start();

--- a/models/FuncAclInitialisation.php
+++ b/models/FuncAclInitialisation.php
@@ -40,19 +40,19 @@ class FuncAclInitialisation
         $managementRoleClass = new \core_kernel_classes_Class(TaoOntology::CLASS_URI_MANAGEMENT_ROLE);
         $foundManagementRoles = $managementRoleClass->getInstances(true);
         $managementRolesByExtension = [];
-         
+
         foreach (\common_ext_ExtensionsManager::singleton()->getInstalledExtensions() as $extension) {
             $managementRole = $extension->getManagementRole();
-             
+
             if (empty($managementRole)) {
                 // try to discover it.
                 foreach ($foundManagementRoles as $mR) {
                     $moduleURIs = $mR->getPropertyValues(new \core_kernel_classes_Property(AccessService::PROPERTY_ACL_GRANTACCESS));
-        
+
                     foreach ($moduleURIs as $moduleURI) {
                         $uri = explode('#', $moduleURI);
                         list($type, $extId) = explode('_', $uri[1]);
-                         
+
                         if ($extId == $extension->getId()) {
                             $managementRole = $mR;
                             break 2;
@@ -60,14 +60,12 @@ class FuncAclInitialisation
                     }
                 }
             }
-        
+
             if (!empty($managementRole)) {
                 $managementRolesByExtension[$extension->getId()] = $managementRole;
             }
         }
-         
-        CacheHelper::flush();
-        
+
         foreach (\common_ext_ExtensionsManager::singleton()->getInstalledExtensions() as $extension) {
             if ($extension->getId() != 'generis') {
                 // 2. Grant access to Management Role.

--- a/models/FuncAclInitialisation.php
+++ b/models/FuncAclInitialisation.php
@@ -47,7 +47,9 @@ class FuncAclInitialisation
             if (empty($managementRole)) {
                 // try to discover it.
                 foreach ($foundManagementRoles as $mR) {
-                    $moduleURIs = $mR->getPropertyValues(new \core_kernel_classes_Property(AccessService::PROPERTY_ACL_GRANTACCESS));
+                    $moduleURIs = $mR->getPropertyValues(
+                        new \core_kernel_classes_Property(AccessService::PROPERTY_ACL_GRANTACCESS)
+                    );
 
                     foreach ($moduleURIs as $moduleURI) {
                         $uri = explode('#', $moduleURI);
@@ -71,7 +73,10 @@ class FuncAclInitialisation
                 // 2. Grant access to Management Role.
                 if (!empty($managementRolesByExtension[$extension->getId()])) {
                     $extAccessService = ExtensionAccessService::singleton();
-                    $extAccessService->add($managementRolesByExtension[$extension->getId()]->getUri(), $extAccessService->makeEMAUri($extension->getId()));
+                    $extAccessService->add(
+                        $managementRolesByExtension[$extension->getId()]->getUri(),
+                        $extAccessService->makeEMAUri($extension->getId())
+                    );
                 } else {
                     \common_Logger::i('Management Role not found for extension ' . $extension->getId());
                 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-1097
https://oat-sa.atlassian.net/browse/ADF-1087
https://oat-sa.atlassian.net/browse/ADF-1105

## Goal 

Make the extension not dictating PHP version to easier our PHP maintenance, since the extension does not work in isolation and PHP version should be equally respected to all TAO extensions.