### PR TITLE
feature/REL 985/application cache warmup after instance refresh

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,8 +61,8 @@
     },
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-        "oat-sa/generis": ">=15.22",
-        "oat-sa/tao-core": ">=50.24.6",
+        "oat-sa/generis": ">=15.25",
+        "oat-sa/tao-core": ">=53.3",
         "oat-sa/extension-tao-backoffice": ">=6.0.0"
     }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -18,6 +18,8 @@
  * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
 
+use oat\funcAcl\models\FuncAclServiceProvider;
+use oat\funcAcl\scripts\install\RegisterEvents;
 use oat\funcAcl\scripts\install\RegisterFuncAcl;
 use oat\funcAcl\scripts\update\Updater;
 
@@ -35,6 +37,7 @@ return [
         ],
         'php' => [
             RegisterFuncAcl::class,
+            RegisterEvents::class,
         ],
     ],
     'update' => Updater::class,
@@ -54,5 +57,8 @@ return [
     ],
     'extra' => [
         'structures' => __DIR__ . DIRECTORY_SEPARATOR . 'controller' . DIRECTORY_SEPARATOR . 'structures.xml',
+    ],
+    'containerServiceProviders' => [
+        FuncAclServiceProvider::class
     ],
 ];

--- a/migrations/Version202306211554491526_funcAcl.php
+++ b/migrations/Version202306211554491526_funcAcl.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023(original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\funcAcl\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\funcAcl\models\listener\AclCacheWarmupListener;
+use oat\generis\model\data\event\CacheWarmupEvent;
+use oat\oatbox\event\EventManager;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ *
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202306211554491526_funcAcl extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Register cache warmup listeners.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        /** @var EventManager $eventManager */
+        $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
+        $eventManager->attach(CacheWarmupEvent::class, [AclCacheWarmupListener::class, 'handleEvent']);
+        $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
+    }
+
+    public function down(Schema $schema): void
+    {
+        /** @var EventManager $eventManager */
+        $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
+        $eventManager->detach(CacheWarmupEvent::class, [AclCacheWarmupListener::class, 'handleEvent']);
+        $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
+    }
+}

--- a/models/FuncAclServiceProvider.php
+++ b/models/FuncAclServiceProvider.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\funcAcl\models;
+
+use oat\funcAcl\models\listener\AclCacheWarmupListener;
+use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+/**
+ * @codeCoverageIgnore
+ */
+class FuncAclServiceProvider implements ContainerServiceProviderInterface
+{
+    public function __invoke(ContainerConfigurator $configurator): void
+    {
+        $services = $configurator->services();
+
+        $services->set(AclCacheWarmupListener::class, AclCacheWarmupListener::class)
+            ->public()
+            ->args(
+                [
+                    service(\common_ext_ExtensionsManager::SERVICE_ID),
+                ]
+            );
+    }
+}

--- a/models/listener/AclCacheWarmupListener.php
+++ b/models/listener/AclCacheWarmupListener.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\funcAcl\models\listener;
+
+use oat\funcAcl\helpers\CacheHelper;
+use oat\generis\model\data\event\CacheWarmupEvent;
+use oat\oatbox\reporting\Report;
+use oat\tao\helpers\ControllerHelper;
+
+/**
+ * @codeCoverageIgnore Ignore because it uses static method which can't be easily tested
+ */
+class AclCacheWarmupListener
+{
+    private \common_ext_ExtensionsManager $extensionsManager;
+
+    public function __construct(
+        \common_ext_ExtensionsManager $extensionsManager
+    ) {
+        $this->extensionsManager = $extensionsManager;
+    }
+
+    public function handleEvent(CacheWarmupEvent $event): void
+    {
+        foreach ($this->extensionsManager->getInstalledExtensionsIds() as $extId) {
+            if ('generis' === $extId) {
+                continue;
+            }
+
+            CacheHelper::getExtensionAccess($extId);
+            foreach (ControllerHelper::getControllers($extId) as $controllerClassName) {
+                CacheHelper::getControllerAccess($controllerClassName);
+                foreach (ControllerHelper::getActions($controllerClassName) as $actionName) {
+                    ControllerHelper::getRequiredRights($controllerClassName, $actionName);
+                }
+            }
+        }
+        $event->addReport(Report::createInfo('Generated ACL cache.'));
+    }
+}

--- a/scripts/install/RegisterEvents.php
+++ b/scripts/install/RegisterEvents.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ */
+
+declare(strict_types=1);
+
+namespace oat\funcAcl\scripts\install;
+
+use oat\funcAcl\models\listener\AclCacheWarmupListener;
+use oat\generis\model\data\event\CacheWarmupEvent;
+use oat\oatbox\event\EventManager;
+use oat\oatbox\extension\InstallAction;
+use oat\oatbox\reporting\Report;
+
+class RegisterEvents extends InstallAction
+{
+    public function __invoke($params)
+    {
+        /** @var EventManager $eventManager */
+        $eventManager = $this->getServiceManager()->get(EventManager::SERVICE_ID);
+        $eventManager->attach(
+            CacheWarmupEvent::class,
+            [AclCacheWarmupListener::class, 'handleEvent']
+        );
+        $this->getServiceManager()->register(EventManager::SERVICE_ID, $eventManager);
+
+        return Report::createSuccess('Events registered');
+    }
+}


### PR DESCRIPTION
## Goal
Premium EC2 instances are recycled every night. This clears the application cache and results in slow first requests until the cache is refilled. The purpose of this PR is to implement a solution for warming up the cache after the instance refresh to improve the performance of the first requests.

## Changelog
- feat: add new command which allow to warmup of the application cache.

## How to test / use
You can run following command to execute  command. `--clear` flag clens up cache before warming it up and can be useful in case of issues or interrupted execution of previous command
```bash
php index.php 'oat\generis\scripts\tools\ApplicationCacheWarmup' --clear
```

## Dependencies
- https://github.com/oat-sa/generis/pull/1051